### PR TITLE
Use a real temporary directory if the __DIR__ path is not writable

### DIFF
--- a/src/SoapClientPlus.php
+++ b/src/SoapClientPlus.php
@@ -66,7 +66,7 @@ class SoapClientPlus extends \SoapClient implements ICurlPlusContainer
 
             if ($wsdlCachePath === false || !is_writable($wsdlCachePath))
             {
-                $wsdlCachePath = realpath(__DIR__).DIRECTORY_SEPARATOR.'WSDL';
+                $wsdlCachePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'WSDL';
 
                 $created = mkdir($wsdlCachePath);
 


### PR DESCRIPTION
Hi, we have noticed that errors are thrown when the source directory is not writable. We propose to use a real temp dir provided by the system when the default folder is not writable.
