### PR TITLE
Updated for PHP 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
 
     "require" : {
-        "php" : ">=5.4.0",
+        "php" : "^8.0",
         "lib-curl" : "*",
         "lib-libxml" : "*",
         "ext-soap" : "*",

--- a/src/SoapClientPlus.php
+++ b/src/SoapClientPlus.php
@@ -118,7 +118,7 @@ class SoapClientPlus extends \SoapClient
         else
             $this->_sxeArgs = LIBXML_COMPACT | LIBXML_NOBLANKS;
 
-        parent::SoapClient($wsdl, $this->_soapOptions);
+        parent::__construct($wsdl, $this->_soapOptions);
     }
 
     /**


### PR DESCRIPTION
Updated for PHP 8 compatibility of SoapClientPlus constructor. Restricted PHP version in composer to ^8.0